### PR TITLE
Change default merge_method for metersphere

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -64,7 +64,7 @@ tide:
     - JohnNiang # For test only
   merge_method:
     halo-dev: squash
-    metersphere: squash
+    metersphere: rebase
     JohnNiang: squash # For test only
     
 


### PR DESCRIPTION
Change the default merge method for metersphere's repos from `squash` to `rebase`.