### PR TITLE
Config approve plugin require_self_approval to true

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -86,6 +86,9 @@ label:
     - tide/merge-method-rebase
     - tide/merge-method-squash
     
+approve:
+  - require_self_approval: true
+    
 welcome:
 - repos:
   - halo-dev


### PR DESCRIPTION
### Why we need it?

This config item try to prevent from adding approved labels automatically if one PR author is an approver in OWNERS. But I'm not sure if this config item does work well or not.

See https://pkg.go.dev/k8s.io/test-infra/prow/plugins#Approve for more.

/kind chore
/cc @halo-dev/sig-infra 
