### PR TITLE
Add repos config item for approve plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -89,7 +89,8 @@ label:
 approve:
   - repos:
       - halo-dev
-      - JohnNiang # Only for test
+      - metersphere
+      - JohnNiang/action-test # Only for test
     require_self_approval: true
     
 welcome:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -87,7 +87,10 @@ label:
     - tide/merge-method-squash
     
 approve:
-  - require_self_approval: true
+  - repos:
+      - halo-dev
+      - JohnNiang # Only for test
+    require_self_approval: true
     
 welcome:
 - repos:


### PR DESCRIPTION
### What this PR does?

Add repos config item for approve plugin.

See https://github.com/kubernetes/test-infra/blob/83bf07dd99d23a5d6998490ec35240a4be895254/prow/plugins/approve/approve.go#L439-L441 for more.

/kind chore
/cc @halo-dev/sig-infra 