### PR TITLE
Fix invalid configuration on cherrypicker plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -111,7 +111,10 @@ welcome:
 
 external_plugins:
   halo-dev:
-    - name: cherrypick
+    - name: cherrypicker
       events:
         - issue_comment
+        - pull_request
+    - name: needs-rebase
+      events:
         - pull_request


### PR DESCRIPTION
### What this PR does

1. Fix invalid configuration on cherrypicker plugin
2. Config needs-rebase plugin as well

See https://github.com/kubernetes/test-infra/blob/87447de9042212409f63ac291789f20612c5e588/config/prow/plugins.yaml#L1290 for more.

/kind bug
/cherrypick release-1.5