### PR TITLE
Add postsubmits and periodics jobs to redeploy Prow and sync labels

### DIFF
--- a/config/jobs/halo-dev/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/halo-dev/test-infra/test-infra-trusted.yaml
@@ -1,0 +1,53 @@
+postsubmits:
+  halo-dev/test-infra:
+    - name: post-test-infra-deploy-prow
+      run_if_changed: '^(config/prow/cluster/|config/prow/Makefile$)'
+      decorate: true
+      branches:
+        - ^main$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: deployer
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/gcloud-in-go:v20220314-46af1b01a6
+            command:
+              - make
+            args:
+              - -C
+              - config/prow
+              - deploy-prow
+
+periodics:
+  - cron: "17 * * * *"  # Every hour at 17 minutes past the hour
+    name: ci-test-infra-label-sync
+    labels:
+      app: label-sync
+    decorate: true
+    spec:
+      containers:
+        - name: label-sync
+          image: gcr.io/k8s-prow/label_sync:v20220330-40eb179576
+          command:
+            - label_sync
+          args:
+            - --config=/etc/config/labels.yaml
+            - --confirm=true
+            - --orgs=halo-dev
+            - --token=/etc/github/token
+            - --endpoint=http://ghproxy.default.svc.cluster.local
+            - --endpoint=https://api.github.com
+            - --debug
+          volumeMounts:
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: oauth
+          secret:
+            secretName: github-token
+        - name: config
+          configMap:
+            name: label-config

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -37,6 +37,7 @@ spec:
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml
+            - --job-config-path=/etc/job-config
             - --s3-credentials-file=/etc/s3-credentials/service-account.json
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
@@ -50,9 +51,15 @@ spec:
                 secretKeyRef:
                   name: github-token
                   key: appid
+          ports:
+            - name: metrics
+              containerPort: 9090
           volumeMounts:
             - name: config
               mountPath: /etc/config
+              readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
               readOnly: true
             - name: github-token
               mountPath: /etc/github
@@ -64,6 +71,9 @@ spec:
         - name: config
           configMap:
             name: config
+        - name: job-config
+          configMap:
+            name: job-config
         - name: github-token
           secret:
             secretName: github-token

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -41,6 +41,7 @@ spec:
           image: gcr.io/k8s-prow/deck:v20220411-ad5dbdfe6e
           args:
             - --config-path=/etc/config/config.yaml
+            - --job-config-path=/etc/job-config
             - --plugin-config=/etc/plugins/plugins.yaml
             - --tide-url=http://tide.default/
             - --hook-url=http://hook:8888/plugin-help
@@ -60,9 +61,14 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+            - name: metrics
+              containerPort: 9090
           volumeMounts:
             - name: config
               mountPath: /etc/config
+              readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
               readOnly: true
             - name: github-token
               mountPath: /etc/github
@@ -90,6 +96,9 @@ spec:
         - name: config
           configMap:
             name: config
+        - name: job-config
+          configMap:
+            name: job-config
         - name: github-token
           secret:
             secretName: github-token

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -43,6 +43,7 @@ spec:
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml
+            - --job-config-path=/etc/job-config
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
             - --github-app-id=$(GITHUB_APP_ID)
@@ -56,6 +57,8 @@ spec:
           ports:
             - name: http
               containerPort: 8888
+            - name: metrics
+              containerPort: 9090
           volumeMounts:
             - name: hmac
               mountPath: /etc/webhook
@@ -65,6 +68,9 @@ spec:
               readOnly: true
             - name: config
               mountPath: /etc/config
+              readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
               readOnly: true
             - name: plugins
               mountPath: /etc/plugins
@@ -92,6 +98,9 @@ spec:
         - name: config
           configMap:
             name: config
+        - name: job-config
+          configMap:
+            name: job-config
         - name: plugins
           configMap:
             name: plugins

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -39,11 +39,21 @@ spec:
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml
+            - --job-config-path=/etc/job-config
+          ports:
+            - name: metrics
+              containerPort: 9090
           volumeMounts:
             - name: config
               mountPath: /etc/config
+              readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
               readOnly: true
       volumes:
         - name: config
           configMap:
             name: config
+        - name: job-config
+          configMap:
+            name: job-config

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -35,6 +35,7 @@ spec:
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml
+            - --job-config-path=/etc/job-config
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
@@ -47,12 +48,18 @@ spec:
                   name: github-token
                   key: appid
           image: gcr.io/k8s-prow/prow-controller-manager:v20220411-ad5dbdfe6e
+          ports:
+            - name: metrics
+              containerPort: 9090
           volumeMounts:
             - name: github-token
               mountPath: /etc/github
               readOnly: true
             - name: config
               mountPath: /etc/config
+              readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
               readOnly: true
       volumes:
         - name: github-token
@@ -61,3 +68,6 @@ spec:
         - name: config
           configMap:
             name: config
+        - name: job-config
+          configMap:
+            name: job-config

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -21,12 +21,22 @@ spec:
           image: gcr.io/k8s-prow/sinker:v20220411-ad5dbdfe6e
           args:
             - --config-path=/etc/config/config.yaml
+            - --job-config-path=/etc/job-config
             - --dry-run=false
+          ports:
+            - name: metrics
+              containerPort: 9090
           volumeMounts:
             - name: config
               mountPath: /etc/config
+              readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
               readOnly: true
       volumes:
         - name: config
           configMap:
             name: config
+        - name: job-config
+          configMap:
+            name: job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -39,6 +39,7 @@ spec:
             - --continue-on-error=true
             - --plugin-config=/etc/plugins/plugins.yaml
             - --config-path=/etc/config/config.yaml
+            - --job-config-path=/etc/job-config
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
             - --s3-credentials-file=/etc/s3-credentials/service-account.json
@@ -58,6 +59,9 @@ spec:
             - name: config
               mountPath: /etc/config
               readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
+              readOnly: true
             - name: plugins
               mountPath: /etc/plugins
               readOnly: true
@@ -71,6 +75,9 @@ spec:
         - name: config
           configMap:
             name: config
+        - name: job-config
+          configMap:
+            name: job-config
         - name: plugins
           configMap:
             name: plugins

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -38,6 +38,7 @@ spec:
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml
+            - --job-config-path=/etc/job-config
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
             - --github-graphql-endpoint=http://ghproxy/graphql
@@ -55,6 +56,8 @@ spec:
           ports:
             - name: http
               containerPort: 8888
+            - name: metrics
+              containerPort: 9090
           volumeMounts:
             - name: github-token
               mountPath: /etc/github
@@ -64,6 +67,9 @@ spec:
               readOnly: true
             - name: s3-credentials
               mountPath: /etc/s3-credentials
+              readOnly: true
+            - name: job-config
+              mountPath: /etc/job-config
               readOnly: true
       volumes:
         - name: github-token
@@ -75,3 +81,6 @@ spec:
         - name: s3-credentials
           secret:
             secretName: s3-credentials
+        - name: job-config
+          configMap:
+            name: job-config

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -71,6 +71,9 @@ config_updater:
       name: plugins
     config/prow/labels.yaml:
       name: label-config
+    config/jobs/**/*.{yaml,yml}:
+      name: job-config
+      gzip: true
 
 # Lower bounds in number of lines changed; XS is assumed to be zero.
 size:


### PR DESCRIPTION
#### What type of PR is this?

/area infra
/kind feature

#### What this PR does / Why we need it:

1. Add postsubmits and periodics jobs to redeploy Prow and sync labels
2. Refine job-config argument on some deployments

#### Does this PR introduce a user-facing change?
```release-note
None
```