### PR TITLE
Add merge_commit_template for tide plugin

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -68,6 +68,10 @@ tide:
     f2ccloud: squash
     metersphere: rebase
     JohnNiang: squash # For test only
-    
+  merge_commit_template:
+    ti-community-infra/test-dev:
+      title: "{{ .Title }} (#{{ .Number }})"
+      body: |
+        {{ .Body }}
 
 decorate_all_jobs: true


### PR DESCRIPTION
### What this PR does / Why we need it

This PR add merge_commit_template config for tide plugin to prevent GitHub from squashing PR which has only one commit with the first commit.

This behaviour is explained at [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#merge-message-for-a-squash-merge).

### References

- https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/config.md#general-configuration
- https://book.prow.tidb.io/#/components/tide?id=%e8%87%aa%e5%ae%9a%e4%b9%89-commit-message-template-%e6%a8%a1%e6%9d%bf
- https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#merge-message-for-a-squash-merge

/kind improvement

```release-note
None
```