### PR TITLE
Add halo-sigs organization into prow

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -60,16 +60,22 @@ tide:
     - do-not-merge/invalid-owners-file
     orgs:
     - halo-dev
+    - halo-sigs
     - metersphere
     - f2ccloud
     - JohnNiang # For test only
   merge_method:
     halo-dev: squash
+    halo-sigs: squash
     f2ccloud: squash
     metersphere: rebase
     JohnNiang: squash # For test only
   merge_commit_template:
-    ti-community-infra/test-dev:
+    halo-dev:
+      title: "{{ .Title }} (#{{ .Number }})"
+      body: |
+        {{ .Body }}
+    halo-sigs:
       title: "{{ .Title }} (#{{ .Number }})"
       body: |
         {{ .Body }}

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -20,6 +20,27 @@ plugins:
       - milestone
       - milestonestatus
       - release-note
+  halo-sigs:
+    plugins:
+      - approve
+      - assign
+      - blunderbuss
+      - cat
+      - dog
+      - help
+      - heart
+      - hold
+      - label
+      - lgtm
+      - trigger
+      - verify-owners
+      - wip
+      - yuks
+      - retitle
+      - lifecycle
+      - milestone
+      - milestonestatus
+      - release-note
   metersphere:
     plugins:
       - approve
@@ -114,6 +135,7 @@ label:
 approve:
   - repos:
       - halo-dev
+      - halo-sigs
       - metersphere
       - f2ccloud
       - JohnNiang/action-test # Only for test


### PR DESCRIPTION
### What this PR does

As I mentioned in the title, I add [halo-sigs](https://github.com/halo-sigs) organization into Prow.

Before this PR is merged, please install the [f2c-ci-robot](https://github.com/apps/f2c-ci-robot) app by the owner of [halo-sigs](https://github.com/halo-sigs) organization (@ruibaby ).

/kind feature

```release-note
None
```