### PR TITLE
refactor: rename admin to console

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -337,8 +337,8 @@ default:
       prowPlugin: label
       addedBy: anyone
     - color: d2b48c
-      description: Categorizes an issue or PR as relevant to SIG Halo Admin.
-      name: sig/halo-admin
+      description: Categorizes an issue or PR as relevant to SIG Halo Console.
+      name: sig/halo-console
       target: both
       prowPlugin: label
       addedBy: anyone
@@ -452,8 +452,8 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
-        description: Issues or PRs related to the Halo Admin 
-        name: area/admin
+        description: Issues or PRs related to the Halo Console 
+        name: area/console
         target: both
         addedBy: label
       - color: 0052cc


### PR DESCRIPTION
### What this PR does?
修改 label: area/admin 为 area/console
修改 sigs: sigs/halo-admin 为 sig/halo-console

see https://github.com/halo-dev/halo/issues/2519

```release-note
None
```