### PR TITLE
Add ui label

### DIFF
--- a/config/prow/labels.yaml
+++ b/config/prow/labels.yaml
@@ -456,6 +456,11 @@ repos:
         name: area/console
         target: both
         addedBy: label
+      - color: 1d76db
+        description: Issues or PRs related to the Halo UI
+        name: area/ui
+        target: both
+        addedBy: label
       - color: 0052cc
         description: Issues or PRs related to the Halo Comment
         name: area/comment


### PR DESCRIPTION
添加 area/ui 的 label，用于涵盖 console 和 uc。

<img width="906" alt="image" src="https://github.com/halo-dev/test-infra/assets/21301288/cdb3db09-ace2-4fef-bc2b-dd28a1ac4734">



```release-note
None
```