### PR TITLE
Remove blunderbuss plugin for halo-sigs and lxware-dev orgs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -23,7 +23,6 @@ plugins:
     plugins:
       - approve
       - assign
-      - blunderbuss
       - cat
       - dog
       - help
@@ -64,7 +63,6 @@ plugins:
     plugins:
       - approve
       - assign
-      - blunderbuss
       - cat
       - dog
       - help


### PR DESCRIPTION
```release-note
None
```

