### PR TITLE
Add repo_milestone configuration for lxware-dev organization

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -169,6 +169,10 @@ repo_milestone:
     maintainers_id: 5847331
     maintainers_team: milestone-maintainers
     maintainers_friendly_name: Milestone Maintainers Team
+  lxware-dev:
+    maintainers_id: 16006972
+    maintainers_team: milestone-maintainers
+    maintainers_friendly_name: Milestone Maintainers
 
 welcome:
   - repos:


### PR DESCRIPTION
This PR adds repo_milestone configuration for lxware-dev organization.

- Configures milestone-maintainers team (ID: 16006972) as the maintainers for lxware-dev organization
- This allows the milestone-maintainers team to manage milestones for repositories under lxware-dev

```release-note
None
```